### PR TITLE
前回出力した値が再計算時に削除されないため、計算結果を出力する前に以前の結果を削除するように修正

### DIFF
--- a/main.gs
+++ b/main.gs
@@ -107,6 +107,12 @@ function subtractBreakTime(today, rest) {
  * @param appliedTime 休憩時間適用後の勤務時間
  */
 function writeCalculatedTime(sheet, appliedTime) {
+  // 2019年03月31日　以前の出力値削除対応　Start
+  // 計算した勤務時間を出力する前に前回の出力値を削除する
+  sheet.getRange('E3:E33').clearContent();
+  // 2019年03月31日　以前の出力値削除対応　End
+
+  // 計算した勤務時間をE列に出力する
   sheet.getRange('E3:E33').setValues(appliedTime);
 }
 


### PR DESCRIPTION
前回出力した値が再計算時に削除されないため、計算結果を出力する前に以前の結果を削除するように修正しました。